### PR TITLE
If pipenv is not install fallback to python system install

### DIFF
--- a/files/nvim/lua/ag/plugins/lsp.lua
+++ b/files/nvim/lua/ag/plugins/lsp.lua
@@ -26,7 +26,7 @@ local efm = {
     dependencies = { "neovim/nvim-lspconfig" },
     config = function()
         local custom_attach = require("ag.lsp_config").custom_attach
-        local get_pipenv_venv_path = require("ag.lsp_config").get_pipenv_venv_path
+        local get_pipenv_venv_path = require("ag.lsp_config").get_python_path
         local lspconfig = require("lspconfig")
 
         local eslint = require("efmls-configs.linters.eslint_d")


### PR DESCRIPTION
Hey, I was navigating in reddit and I found your response to this post: [Neovim subreddit](https://www.reddit.com/r/neovim/comments/rjrytp/which_python_lsp_is_better/). I was amazed by how you set up the python path  to a virtual env in LSP, so I did some research and found a way to fall back to system installation if there is no pipenv installed.

Hope this is useful in some way!